### PR TITLE
Fetch all bets once and cache in Pinia store

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,34 @@
+# API Endpoints
+
+All endpoints used by this frontend, targeting the backend version defined in `backendApiVersion` in `package.json`. The client SDK is auto-generated from the backend OpenAPI spec — run `npm run generate-client` to regenerate after backend changes.
+
+## Authentication
+
+| Method | Endpoint | Used in |
+|--------|----------|---------|
+| `POST` | `/api/v1/users/login` | `LoginComponent` |
+| `POST` | `/api/v1/users/signup` | `SignupComponent` |
+| `POST` | `/api/v1/users/logout` | `TopNavbar` |
+
+## Bets
+
+| Method | Endpoint | Used in |
+|--------|----------|---------|
+| `GET` | `/api/v1/bets/` | `store/index` — fetched once at login and on page reload if store is empty, cached in Pinia |
+| `GET` | `/api/v1/bets/groups/rank/{group_code}` | `GroupComponent` — fetched per group navigation |
+| `GET` | `/api/v1/bets/phases/{phase_code}` | `FinalePhaseComponent` |
+| `PATCH` | `/api/v1/score_bets/{bet_id}` | `GroupComponent` |
+| `PATCH` | `/api/v1/binary_bets/{bet_id}` | `FinalePhaseComponent` |
+
+## Results & Scoreboard
+
+| Method | Endpoint | Used in |
+|--------|----------|---------|
+| `GET` | `/api/v1/results` | `HomeComponent` |
+| `GET` | `/api/v1/score_board` | `ScoreBoardComponent` |
+
+## Rules
+
+| Method | Endpoint | Used in |
+|--------|----------|---------|
+| `POST` | `/api/v1/rules/{rule_id}` | `TopNavbar` (compute points, admin only), `FinalePhaseComponent` |

--- a/src/components/LoginComponent.vue
+++ b/src/components/LoginComponent.vue
@@ -68,6 +68,7 @@ const login = async () => {
   if (data) {
     yakStore.setLoggedIn(true);
     yakStore.setUserName(data.result.name);
+    await yakStore.fetchAllBets();
 
     router.push('/home');
   } else {

--- a/src/components/SignupComponent.vue
+++ b/src/components/SignupComponent.vue
@@ -87,6 +87,7 @@ const signup = async () => {
   if (data) {
     yakStore.setLoggedIn(true);
     yakStore.setUserName(data.result.name);
+    await yakStore.fetchAllBets();
 
     router.push('/home');
   } else {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,7 +1,13 @@
 import { defineStore } from 'pinia';
+import type { AllBetsResponse, ScoreBetWithGroupIdOut } from '@/client';
+import { retrieveAllBetsApiV1BetsGet } from '@/client';
 
 const useYakStore = defineStore('yakStorage', {
-  state: () => ({ userName: '', isLoggedIn: false }),
+  state: () => ({
+    userName: '',
+    isLoggedIn: false,
+    allBets: null as AllBetsResponse | null,
+  }),
   getters: {
     getUserName: (state) => state.userName,
   },
@@ -18,8 +24,24 @@ const useYakStore = defineStore('yakStorage', {
     isAuthenticated() {
       return this.isLoggedIn;
     },
+    async fetchAllBets() {
+      const { data } = await retrieveAllBetsApiV1BetsGet();
+      if (data) {
+        this.allBets = data.result;
+      }
+    },
+    updateStoreBets(updatedBets: ScoreBetWithGroupIdOut[]) {
+      if (!this.allBets) return;
+      const updatedIds = new Set(updatedBets.map((b) => b.id));
+      this.allBets.score_bets = this.allBets.score_bets.map((bet) => {
+        const updated = updatedBets.find((b) => b.id === bet.id);
+        return updatedIds.has(bet.id) && updated ? updated : bet;
+      });
+    },
   },
-  persist: true,
+  persist: {
+    pick: ['userName', 'isLoggedIn'],
+  },
 });
 
 export default useYakStore;


### PR DESCRIPTION
Replace per-group API calls with a single GET /api/v1/bets/ call at login/signup time. Store the result in Pinia (unpersisted) and have GroupComponent and GroupNavbar read from it instead of making individual requests on each navigation. On page reload, both components detect an empty store and re-fetch transparently. Only the group rank call remains per-navigation as no bulk endpoint exists.