### PR TITLE
feat: adapt to yak-server 0.76.0 dynamic knockout rounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.14.2",
   "private": true,
   "type": "module",
-  "backendApiVersion": "0.74.0",
+  "backendApiVersion": "0.76.0",
   "engines": {
     "node": "^24.0.0"
   },

--- a/src/components/HomeComponent.vue
+++ b/src/components/HomeComponent.vue
@@ -45,9 +45,7 @@ const userResult = ref<UserResult>({
   number_score_guess: 0,
   number_qualified_teams_guess: 0,
   number_first_qualified_guess: 0,
-  number_quarter_final_guess: 0,
-  number_semi_final_guess: 0,
-  number_final_guess: 0,
+  knockout_rounds: [],
   number_winner_guess: 0,
   points: 0,
 });
@@ -57,9 +55,10 @@ const stats = computed(() => [
   { label: 'Scores trouvés', value: userResult.value.number_score_guess },
   { label: 'Qualifiés trouvés', value: userResult.value.number_qualified_teams_guess },
   { label: 'Premiers trouvés', value: userResult.value.number_first_qualified_guess },
-  { label: 'Quart de finalistes', value: userResult.value.number_quarter_final_guess },
-  { label: 'Demi-finalistes', value: userResult.value.number_semi_final_guess },
-  { label: 'Finalistes', value: userResult.value.number_final_guess },
+  ...userResult.value.knockout_rounds.map((round) => ({
+    label: round.group.description,
+    value: round.count,
+  })),
   { label: 'Vainqueur trouvé', value: userResult.value.number_winner_guess },
 ]);
 

--- a/src/components/ScoreBoardComponent.vue
+++ b/src/components/ScoreBoardComponent.vue
@@ -10,22 +10,18 @@
               <th>Nombre de scores trouvés</th>
               <th>Nombre de qualifiés trouvés</th>
               <th>Nombre de premier trouvés</th>
-              <th>Nombre de quart de finalistes</th>
-              <th>Nombre de demi-finalistes</th>
-              <th>Nombre de finalistes</th>
+              <th v-for="group in scoreBoardResource.groups" :key="group.id">{{ group.description }}</th>
               <th>Vainqueur trouvé</th>
               <th>Points</th>
             </tr>
           </thead>
-          <tr v-for="res in scoreBoardResource" :key="res.full_name">
+          <tr v-for="res in scoreBoardResource.results" :key="res.full_name">
             <td>{{ res.full_name }}</td>
             <td>{{ res.number_match_guess }}</td>
             <td>{{ res.number_score_guess }}</td>
             <td>{{ res.number_qualified_teams_guess }}</td>
             <td>{{ res.number_first_qualified_guess }}</td>
-            <td>{{ res.number_quarter_final_guess }}</td>
-            <td>{{ res.number_semi_final_guess }}</td>
-            <td>{{ res.number_final_guess }}</td>
+            <td v-for="group in scoreBoardResource.groups" :key="group.id">{{ res.knockout_rounds.find(r => r.group_id === group.id)?.count ?? 0 }}</td>
             <td>{{ res.number_winner_guess }}</td>
             <td>{{ res.points }}</td>
           </tr>
@@ -36,11 +32,11 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import type { UserResult } from '@/client';
+import type { ScoreBoardResponse } from '@/client';
 import { retrieveScoreBoardApiV1ScoreBoardGet } from '@/client';
 
 // Reactive data
-const scoreBoardResource = ref<UserResult[]>([]);
+const scoreBoardResource = ref<ScoreBoardResponse>({ groups: [], results: [] });
 
 // Methods
 const getScoreBoard = async () => {


### PR DESCRIPTION
Replace fixed quarter/semi/final fields with a dynamic `knockout_rounds` array in both HomeComponent and ScoreBoardComponent.